### PR TITLE
Changed CellFormulaValue to include possible absence of result

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -333,7 +333,7 @@ export interface CellHyperlinkValue {
 
 export interface CellFormulaValue {
 	formula: string;
-	result: number | string | Date;
+	result?: number | string | Date;
 }
 
 export interface CellSharedFormulaValue {


### PR DESCRIPTION
It is currently possible, when passing a formula as a value, to omit the result of the formula, and the result will be computed later.
`sheet.getCell("B1").value = { formula: 'SUM(A1:A6)' };`

This PR aims to add this possible syntax to the TypeScript module resolution file.